### PR TITLE
Migrate to TypeScript and refactor architecture

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,6 +21,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run build
       - uses: actions/configure-pages@v5
       - uses: actions/upload-pages-artifact@v3
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 node_modules/
-package.json
-package-lock.json
+js/*.js.map
 test-debug-flow.js

--- a/css/style.css
+++ b/css/style.css
@@ -158,6 +158,10 @@ h2 {
   overflow: hidden;
 }
 
+#btn-scan-answer {
+  margin-top: 16px;
+}
+
 /* Chat layout */
 #screen-chat {
   display: none;

--- a/index.html
+++ b/index.html
@@ -36,6 +36,7 @@
       <p class="instruction" id="host-instruction">Show this QR code to your peer</p>
       <div id="host-qr-container" class="qr-container"></div>
       <div id="host-scanner-container" class="scanner-container hidden"></div>
+      <button id="btn-scan-answer" class="btn btn-primary hidden">Scan Answer QR</button>
 
       <!-- Debug: text paste for SDP exchange -->
       <div id="host-debug" class="debug-panel hidden">
@@ -93,8 +94,10 @@
   <script src="lib/html5-qrcode.min.js"></script>
 
   <!-- App modules -->
+  <script src="js/types.js"></script>
   <script src="js/identity.js"></script>
   <script src="js/screens.js"></script>
+  <script src="js/toast.js"></script>
   <script src="js/sdp-compress.js"></script>
   <script src="js/transport.js"></script>
   <script src="js/webrtc-transport.js"></script>

--- a/js/app.js
+++ b/js/app.js
@@ -1,253 +1,199 @@
-(function () {
-  'use strict';
-
-  var BC = window.BlueChat;
-  var transport = null;
-  var deviceId = '';
-  var peerId = '';
-  var isDebug = window.location.search.indexOf('debug=true') !== -1;
-
-  // Toast notifications
-  function toast(msg, isError) {
-    var container = document.getElementById('toast-container');
-    var el = document.createElement('div');
-    el.className = 'toast' + (isError ? ' toast-error' : '');
-    el.textContent = msg;
-    container.appendChild(el);
-    setTimeout(function () {
-      el.classList.add('toast-out');
-      setTimeout(function () { el.remove(); }, 300);
-    }, 5000);
-  }
-
-  // Clean up transport and scanner
-  function cleanup() {
-    BC.QRManager.stopScanner();
-    if (transport) {
-      transport.disconnect();
-      transport = null;
-    }
-  }
-
-  // Setup transport event handlers
-  function setupTransport() {
-    // Expose for debugging
-    BC._transport = transport;
-
-    transport.on('connected', function () {
-      BC.Screens.show('chat');
-      BC.Chat.clear();
-      var name = peerId || 'Peer';
-      document.getElementById('peer-name').textContent = name;
-      document.getElementById('status-dot').classList.remove('disconnected');
-      BC.Chat.addMessage('Connected to ' + name, 'system');
-    });
-
-    transport.on('disconnected', function () {
-      document.getElementById('status-dot').classList.add('disconnected');
-      BC.Chat.addMessage('Peer disconnected', 'system');
-    });
-
-    transport.on('message', function (data) {
-      try {
-        var msg = JSON.parse(data);
-        if (msg.type === 'chat') {
-          BC.Chat.addMessage(msg.text, 'received');
+"use strict";
+var BlueChat;
+(function (BlueChat) {
+    let transport = null;
+    let deviceId = '';
+    let peerId = '';
+    const isDebug = window.location.search.indexOf('debug=true') !== -1;
+    // Expose transport for debugging (used by test-debug-flow.js)
+    BlueChat._transport = null;
+    function cleanup() {
+        BlueChat.QRManager.stopScanner();
+        if (transport) {
+            transport.disconnect();
+            transport = null;
+            BlueChat._transport = null;
         }
-      } catch (e) {
-        // Raw text fallback
-        BC.Chat.addMessage(data, 'received');
-      }
-    });
-  }
-
-  function sendMessage(text) {
-    if (!transport || !text.trim()) return;
-    var msg = JSON.stringify({ type: 'chat', text: text.trim(), from: deviceId });
-    transport.send(msg);
-    BC.Chat.addMessage(text.trim(), 'sent');
-  }
-
-  // Host flow: create offer → show QR → scan answer
-  function startHost() {
-    cleanup();
-    transport = new BC.WebRTCTransport();
-    setupTransport();
-
-    BC.Screens.show('host');
-    document.getElementById('host-instruction').textContent = 'Generating connection code...';
-    document.getElementById('host-qr-container').innerHTML = '';
-    document.getElementById('host-scanner-container').classList.add('hidden');
-
-    transport.createOffer().then(function (sdp) {
-      var compressed = BC.SDPCompress.compress(sdp, 'offer', deviceId);
-      console.log('Offer compressed length:', compressed.length);
-
-      document.getElementById('host-instruction').textContent = 'Show this QR code to your peer';
-      BC.QRManager.displayQR('host-qr-container', compressed);
-
-      // Debug mode: show text fields
-      if (isDebug) {
-        document.getElementById('host-offer-text').value = compressed;
-      }
-
-      // If not debug, auto-switch to camera after showing QR
-      if (!isDebug) {
-        // Wait a moment then switch to scanning for answer
-        waitForAnswerScan();
-      }
-    }).catch(function (err) {
-      toast('Failed to create offer: ' + err.message, true);
-      console.error(err);
-    });
-  }
-
-  function waitForAnswerScan() {
-    // Show instruction to wait, then switch to scanner
-    document.getElementById('host-instruction').textContent =
-      'Waiting for peer... Camera will open after they scan.';
-
-    // Give peer time to scan, then open our camera
-    setTimeout(function () {
-      if (BC.Screens.getCurrent() !== 'host') return;
-
-      document.getElementById('host-instruction').textContent = 'Scan your peer\'s answer QR code';
-      document.getElementById('host-qr-container').classList.add('hidden');
-      document.getElementById('host-scanner-container').classList.remove('hidden');
-
-      BC.QRManager.startScanner('host-scanner-container', function (data) {
-        processAnswer(data);
-      }).catch(function (err) {
-        toast('Camera error: ' + err, true);
-      });
-    }, 5000);
-  }
-
-  function processAnswer(compressed) {
-    var result = BC.SDPCompress.decompress(compressed);
-    if (!result || result.type !== 'answer') {
-      toast('Invalid answer QR code', true);
-      return;
     }
-    peerId = result.peerId;
-    transport.completeConnection(result.sdp).catch(function (err) {
-      toast('Connection failed: ' + err.message, true);
-    });
-  }
-
-  // Join flow: scan offer QR → create answer → show answer QR
-  function startJoin() {
-    cleanup();
-    transport = new BC.WebRTCTransport();
-    setupTransport();
-
-    BC.Screens.show('join');
-    document.getElementById('join-instruction').textContent = 'Scan the host\'s QR code';
-    document.getElementById('join-qr-container').classList.add('hidden');
-    document.getElementById('join-scanner-container').classList.remove('hidden');
-
-    if (!isDebug) {
-      BC.QRManager.startScanner('join-scanner-container', function (data) {
-        processOffer(data);
-      }).catch(function (err) {
-        toast('Camera error: ' + err, true);
-      });
+    function setupTransport() {
+        BlueChat._transport = transport;
+        transport.on('connected', () => {
+            BlueChat.Screens.show('chat');
+            BlueChat.Chat.clear();
+            const name = peerId || 'Peer';
+            document.getElementById('peer-name').textContent = name;
+            document.getElementById('status-dot').classList.remove('disconnected');
+            BlueChat.Chat.addMessage('Connected to ' + name, 'system');
+        });
+        transport.on('disconnected', () => {
+            document.getElementById('status-dot').classList.add('disconnected');
+            BlueChat.Chat.addMessage('Peer disconnected', 'system');
+        });
+        transport.on('message', (data) => {
+            try {
+                const msg = JSON.parse(data);
+                if (msg.type === 'chat') {
+                    BlueChat.Chat.addMessage(msg.text, 'received');
+                }
+            }
+            catch (_a) {
+                BlueChat.Chat.addMessage(data, 'received');
+            }
+        });
     }
-  }
-
-  function processOffer(compressed) {
-    var result = BC.SDPCompress.decompress(compressed);
-    if (!result || result.type !== 'offer') {
-      toast('Invalid offer QR code', true);
-      return;
+    function sendMessage(text) {
+        if (!transport || !text.trim())
+            return;
+        const msg = { type: 'chat', text: text.trim(), from: deviceId };
+        transport.send(JSON.stringify(msg));
+        BlueChat.Chat.addMessage(text.trim(), 'sent');
     }
-    peerId = result.peerId;
-
-    document.getElementById('join-instruction').textContent = 'Creating answer...';
-
-    transport.acceptOffer(result.sdp).then(function (answerSDP) {
-      var answerCompressed = BC.SDPCompress.compress(answerSDP, 'answer', deviceId);
-      console.log('Answer compressed length:', answerCompressed.length);
-
-      document.getElementById('join-instruction').textContent = 'Show this QR code to the host';
-      document.getElementById('join-scanner-container').classList.add('hidden');
-      document.getElementById('join-qr-container').classList.remove('hidden');
-      BC.QRManager.displayQR('join-qr-container', answerCompressed);
-
-      // Debug mode
-      if (isDebug) {
-        document.getElementById('join-answer-text').value = answerCompressed;
-      }
-    }).catch(function (err) {
-      toast('Failed to create answer: ' + err.message, true);
-      console.error(err);
-    });
-  }
-
-  // Initialize app
-  function init() {
-    deviceId = BC.Identity.getOrCreate();
-    document.getElementById('device-id').textContent = deviceId;
-    BC.Chat.init();
-
-    // Show debug panels if ?debug=true
-    if (isDebug) {
-      document.querySelectorAll('.debug-panel').forEach(function (el) {
-        el.classList.remove('hidden');
-      });
+    // --- Host flow ---
+    function startHost() {
+        cleanup();
+        transport = new BlueChat.WebRTCTransport();
+        setupTransport();
+        BlueChat.Screens.show('host');
+        document.getElementById('host-instruction').textContent = 'Generating connection code...';
+        document.getElementById('host-qr-container').innerHTML = '';
+        document.getElementById('host-scanner-container').classList.add('hidden');
+        document.getElementById('btn-scan-answer').classList.add('hidden');
+        transport.createInvite().then(sdp => {
+            const compressed = BlueChat.SDPCompress.compress(sdp, 'offer', deviceId);
+            console.log('Offer compressed length:', compressed.length);
+            document.getElementById('host-instruction').textContent = 'Show this QR code to your peer';
+            BlueChat.QRManager.displayQR('host-qr-container', compressed);
+            if (isDebug) {
+                document.getElementById('host-offer-text').value = compressed;
+            }
+            // Show "Scan Answer" button (replaces old 5-second auto-switch)
+            if (!isDebug) {
+                document.getElementById('btn-scan-answer').classList.remove('hidden');
+            }
+        }).catch(err => {
+            BlueChat.Toast.show('Failed to create offer: ' + err.message, true);
+            console.error(err);
+        });
     }
-
-    // Button handlers
-    document.getElementById('btn-new-chat').addEventListener('click', startHost);
-    document.getElementById('btn-join-chat').addEventListener('click', startJoin);
-
-    document.getElementById('btn-host-back').addEventListener('click', function () {
-      cleanup();
-      BC.Screens.show('home');
-    });
-
-    document.getElementById('btn-join-back').addEventListener('click', function () {
-      cleanup();
-      BC.Screens.show('home');
-    });
-
-    document.getElementById('btn-leave').addEventListener('click', function () {
-      cleanup();
-      BC.Screens.show('home');
-    });
-
-    // Chat form
-    document.getElementById('chat-form').addEventListener('submit', function (e) {
-      e.preventDefault();
-      var input = document.getElementById('chat-input');
-      sendMessage(input.value);
-      input.value = '';
-    });
-
-    // Debug: host accept answer
-    document.getElementById('host-accept-answer').addEventListener('click', function () {
-      var text = document.getElementById('host-answer-text').value.trim();
-      if (text) processAnswer(text);
-    });
-
-    // Debug: join process offer
-    document.getElementById('join-process-offer').addEventListener('click', function () {
-      var text = document.getElementById('join-offer-text').value.trim();
-      if (text) processOffer(text);
-    });
-
-    // Register service worker
-    if ('serviceWorker' in navigator) {
-      navigator.serviceWorker.register('sw.js').catch(function (err) {
-        console.log('SW registration failed:', err);
-      });
+    function startAnswerScan() {
+        document.getElementById('host-instruction').textContent = "Scan your peer's answer QR code";
+        document.getElementById('host-qr-container').classList.add('hidden');
+        document.getElementById('btn-scan-answer').classList.add('hidden');
+        document.getElementById('host-scanner-container').classList.remove('hidden');
+        BlueChat.QRManager.startScanner('host-scanner-container', (data) => {
+            processAnswer(data);
+        }).catch(err => {
+            BlueChat.Toast.show('Camera error: ' + err, true);
+        });
     }
-  }
-
-  // Boot
-  if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', init);
-  } else {
-    init();
-  }
-})();
+    function processAnswer(compressed) {
+        const result = BlueChat.SDPCompress.decompress(compressed);
+        if (!result || result.type !== 'answer') {
+            BlueChat.Toast.show('Invalid answer QR code', true);
+            return;
+        }
+        peerId = result.peerId;
+        transport.completeHandshake(result.sdp).catch(err => {
+            BlueChat.Toast.show('Connection failed: ' + err.message, true);
+        });
+    }
+    // --- Join flow ---
+    function startJoin() {
+        cleanup();
+        transport = new BlueChat.WebRTCTransport();
+        setupTransport();
+        BlueChat.Screens.show('join');
+        document.getElementById('join-instruction').textContent = "Scan the host's QR code";
+        document.getElementById('join-qr-container').classList.add('hidden');
+        document.getElementById('join-scanner-container').classList.remove('hidden');
+        if (!isDebug) {
+            BlueChat.QRManager.startScanner('join-scanner-container', (data) => {
+                processOffer(data);
+            }).catch(err => {
+                BlueChat.Toast.show('Camera error: ' + err, true);
+            });
+        }
+    }
+    function processOffer(compressed) {
+        const result = BlueChat.SDPCompress.decompress(compressed);
+        if (!result || result.type !== 'offer') {
+            BlueChat.Toast.show('Invalid offer QR code', true);
+            return;
+        }
+        peerId = result.peerId;
+        document.getElementById('join-instruction').textContent = 'Creating answer...';
+        transport.acceptInvite(result.sdp).then(answerSDP => {
+            const answerCompressed = BlueChat.SDPCompress.compress(answerSDP, 'answer', deviceId);
+            console.log('Answer compressed length:', answerCompressed.length);
+            document.getElementById('join-instruction').textContent = 'Show this QR code to the host';
+            document.getElementById('join-scanner-container').classList.add('hidden');
+            document.getElementById('join-qr-container').classList.remove('hidden');
+            BlueChat.QRManager.displayQR('join-qr-container', answerCompressed);
+            if (isDebug) {
+                document.getElementById('join-answer-text').value = answerCompressed;
+            }
+        }).catch(err => {
+            BlueChat.Toast.show('Failed to create answer: ' + err.message, true);
+            console.error(err);
+        });
+    }
+    // --- Init ---
+    function init() {
+        deviceId = BlueChat.Identity.getOrCreate();
+        document.getElementById('device-id').textContent = deviceId;
+        BlueChat.Chat.init();
+        if (isDebug) {
+            document.querySelectorAll('.debug-panel').forEach(el => {
+                el.classList.remove('hidden');
+            });
+        }
+        // Button handlers
+        document.getElementById('btn-new-chat').addEventListener('click', startHost);
+        document.getElementById('btn-join-chat').addEventListener('click', startJoin);
+        document.getElementById('btn-scan-answer').addEventListener('click', startAnswerScan);
+        document.getElementById('btn-host-back').addEventListener('click', () => {
+            cleanup();
+            BlueChat.Screens.show('home');
+        });
+        document.getElementById('btn-join-back').addEventListener('click', () => {
+            cleanup();
+            BlueChat.Screens.show('home');
+        });
+        document.getElementById('btn-leave').addEventListener('click', () => {
+            cleanup();
+            BlueChat.Screens.show('home');
+        });
+        // Chat form
+        document.getElementById('chat-form').addEventListener('submit', (e) => {
+            e.preventDefault();
+            const input = document.getElementById('chat-input');
+            sendMessage(input.value);
+            input.value = '';
+        });
+        // Debug handlers
+        document.getElementById('host-accept-answer').addEventListener('click', () => {
+            const text = document.getElementById('host-answer-text').value.trim();
+            if (text)
+                processAnswer(text);
+        });
+        document.getElementById('join-process-offer').addEventListener('click', () => {
+            const text = document.getElementById('join-offer-text').value.trim();
+            if (text)
+                processOffer(text);
+        });
+        // Service worker
+        if ('serviceWorker' in navigator) {
+            navigator.serviceWorker.register('sw.js').catch(err => {
+                console.log('SW registration failed:', err);
+            });
+        }
+    }
+    // Boot
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    }
+    else {
+        init();
+    }
+})(BlueChat || (BlueChat = {}));
+//# sourceMappingURL=app.js.map

--- a/js/chat.js
+++ b/js/chat.js
@@ -1,50 +1,41 @@
-(function () {
-  'use strict';
-
-  var messagesEl = null;
-
-  function init() {
-    messagesEl = document.getElementById('messages');
-  }
-
-  function clear() {
-    if (messagesEl) messagesEl.innerHTML = '';
-  }
-
-  function formatTime(date) {
-    var h = date.getHours();
-    var m = date.getMinutes();
-    return (h < 10 ? '0' : '') + h + ':' + (m < 10 ? '0' : '') + m;
-  }
-
-  function escapeHTML(text) {
-    var div = document.createElement('div');
-    div.textContent = text;
-    return div.innerHTML;
-  }
-
-  function addMessage(text, type) {
-    if (!messagesEl) return;
-
-    var div = document.createElement('div');
-
-    if (type === 'system') {
-      div.className = 'msg-system';
-      div.textContent = text;
-    } else {
-      div.className = 'msg ' + (type === 'sent' ? 'sent' : 'received');
-      div.innerHTML = escapeHTML(text) +
-        '<span class="msg-time">' + formatTime(new Date()) + '</span>';
+"use strict";
+var BlueChat;
+(function (BlueChat) {
+    let messagesEl = null;
+    function formatTime(date) {
+        const h = date.getHours();
+        const m = date.getMinutes();
+        return (h < 10 ? '0' : '') + h + ':' + (m < 10 ? '0' : '') + m;
     }
-
-    messagesEl.appendChild(div);
-    messagesEl.scrollTop = messagesEl.scrollHeight;
-  }
-
-  window.BlueChat = window.BlueChat || {};
-  window.BlueChat.Chat = {
-    init: init,
-    clear: clear,
-    addMessage: addMessage
-  };
-})();
+    function escapeHTML(text) {
+        const div = document.createElement('div');
+        div.textContent = text;
+        return div.innerHTML;
+    }
+    BlueChat.Chat = {
+        init() {
+            messagesEl = document.getElementById('messages');
+        },
+        clear() {
+            if (messagesEl)
+                messagesEl.innerHTML = '';
+        },
+        addMessage(text, type) {
+            if (!messagesEl)
+                return;
+            const div = document.createElement('div');
+            if (type === 'system') {
+                div.className = 'msg-system';
+                div.textContent = text;
+            }
+            else {
+                div.className = 'msg ' + (type === 'sent' ? 'sent' : 'received');
+                div.innerHTML = escapeHTML(text) +
+                    '<span class="msg-time">' + formatTime(new Date()) + '</span>';
+            }
+            messagesEl.appendChild(div);
+            messagesEl.scrollTop = messagesEl.scrollHeight;
+        }
+    };
+})(BlueChat || (BlueChat = {}));
+//# sourceMappingURL=chat.js.map

--- a/js/identity.js
+++ b/js/identity.js
@@ -1,47 +1,36 @@
-(function () {
-  'use strict';
-
-  var ADJECTIVES = [
-    'bold', 'calm', 'cool', 'dark', 'fast', 'kind', 'keen', 'warm',
-    'wise', 'wild', 'free', 'fair', 'glad', 'gold', 'pink', 'blue',
-    'red', 'soft', 'tall', 'true', 'pure', 'neat', 'slim', 'deep'
-  ];
-
-  var NOUNS = [
-    'fox', 'owl', 'cat', 'dog', 'elk', 'bee', 'ant', 'bat',
-    'cow', 'emu', 'hen', 'jay', 'ram', 'yak', 'ape', 'cod',
-    'fly', 'gnu', 'hog', 'koi', 'lynx', 'pug', 'ray', 'wolf'
-  ];
-
-  function randomHex(len) {
-    var hex = '';
-    var arr = new Uint8Array(len);
-    crypto.getRandomValues(arr);
-    for (var i = 0; i < arr.length; i++) {
-      hex += arr[i].toString(16).padStart(2, '0');
+"use strict";
+var BlueChat;
+(function (BlueChat) {
+    const ADJECTIVES = [
+        'bold', 'calm', 'cool', 'dark', 'fast', 'kind', 'keen', 'warm',
+        'wise', 'wild', 'free', 'fair', 'glad', 'gold', 'pink', 'blue',
+        'red', 'soft', 'tall', 'true', 'pure', 'neat', 'slim', 'deep'
+    ];
+    const NOUNS = [
+        'fox', 'owl', 'cat', 'dog', 'elk', 'bee', 'ant', 'bat',
+        'cow', 'emu', 'hen', 'jay', 'ram', 'yak', 'ape', 'cod',
+        'fly', 'gnu', 'hog', 'koi', 'lynx', 'pug', 'ray', 'wolf'
+    ];
+    function randomHex(len) {
+        const arr = new Uint8Array(len);
+        crypto.getRandomValues(arr);
+        return Array.from(arr, b => b.toString(16).padStart(2, '0')).join('');
     }
-    return hex;
-  }
-
-  function generate() {
-    var adj = ADJECTIVES[Math.floor(Math.random() * ADJECTIVES.length)];
-    var noun = NOUNS[Math.floor(Math.random() * NOUNS.length)];
-    var hex = randomHex(2);
-    return adj + '-' + noun + '-' + hex;
-  }
-
-  function getOrCreate() {
-    var key = 'bluechat-device-id';
-    var id = localStorage.getItem(key);
-    if (!id) {
-      id = generate();
-      localStorage.setItem(key, id);
+    function generate() {
+        const adj = ADJECTIVES[Math.floor(Math.random() * ADJECTIVES.length)];
+        const noun = NOUNS[Math.floor(Math.random() * NOUNS.length)];
+        return `${adj}-${noun}-${randomHex(2)}`;
     }
-    return id;
-  }
-
-  window.BlueChat = window.BlueChat || {};
-  window.BlueChat.Identity = {
-    getOrCreate: getOrCreate
-  };
-})();
+    BlueChat.Identity = {
+        getOrCreate() {
+            const key = 'bluechat-device-id';
+            let id = localStorage.getItem(key);
+            if (!id) {
+                id = generate();
+                localStorage.setItem(key, id);
+            }
+            return id;
+        }
+    };
+})(BlueChat || (BlueChat = {}));
+//# sourceMappingURL=identity.js.map

--- a/js/qr-manager.js
+++ b/js/qr-manager.js
@@ -1,86 +1,52 @@
-(function () {
-  'use strict';
-
-  var activeScanner = null;
-
-  // Generate a QR code into a container element
-  function displayQR(containerId, data) {
-    var container = document.getElementById(containerId);
-    if (!container) return;
-    container.innerHTML = '';
-
-    // Choose error correction level and type based on data length
-    var typeNumber = 0; // auto-detect
-    var errorCorrection = 'L';
-
-    try {
-      var qr = qrcode(typeNumber, errorCorrection);
-      qr.addData(data);
-      qr.make();
-
-      var size = Math.min(264, window.innerWidth - 80);
-      var img = document.createElement('img');
-      img.src = qr.createDataURL(4, 0);
-      img.width = size;
-      img.height = size;
-      img.alt = 'QR Code';
-      img.style.imageRendering = 'pixelated';
-      container.appendChild(img);
-    } catch (e) {
-      container.textContent = 'QR code too large. Use debug mode (?debug=true).';
-      console.error('QR generation error:', e);
-    }
-  }
-
-  // Start camera scanning
-  function startScanner(containerId, onResult) {
-    stopScanner(); // Clean up any previous scanner
-
-    var scanner = new Html5Qrcode(containerId);
-    activeScanner = scanner;
-
-    var config = {
-      fps: 10,
-      qrbox: { width: 250, height: 250 },
-      aspectRatio: 1.0
-    };
-
-    return scanner.start(
-      { facingMode: 'environment' },
-      config,
-      function onScanSuccess(decodedText) {
-        // Stop scanning once we get a result
-        stopScanner();
-        onResult(decodedText);
-      },
-      function onScanFailure() {
-        // Ignore scan failures (no QR in frame)
-      }
-    ).catch(function (err) {
-      console.error('Scanner start error:', err);
-      throw err;
-    });
-  }
-
-  // Stop camera scanning
-  function stopScanner() {
-    if (activeScanner) {
-      var scanner = activeScanner;
-      activeScanner = null;
-      try {
-        if (scanner.isScanning) {
-          scanner.stop().catch(function () { /* ignore */ });
+"use strict";
+var BlueChat;
+(function (BlueChat) {
+    let activeScanner = null;
+    BlueChat.QRManager = {
+        displayQR(containerId, data) {
+            const container = document.getElementById(containerId);
+            if (!container)
+                return;
+            container.innerHTML = '';
+            try {
+                const qr = qrcode(0, 'L');
+                qr.addData(data);
+                qr.make();
+                const size = Math.min(264, window.innerWidth - 80);
+                const img = document.createElement('img');
+                img.src = qr.createDataURL(4, 0);
+                img.width = size;
+                img.height = size;
+                img.alt = 'QR Code';
+                img.style.imageRendering = 'pixelated';
+                container.appendChild(img);
+            }
+            catch (e) {
+                container.textContent = 'QR code too large. Use debug mode (?debug=true).';
+                console.error('QR generation error:', e);
+            }
+        },
+        startScanner(containerId, onResult) {
+            BlueChat.QRManager.stopScanner();
+            const scanner = new Html5Qrcode(containerId);
+            activeScanner = scanner;
+            return scanner.start({ facingMode: 'environment' }, { fps: 10, qrbox: { width: 250, height: 250 }, aspectRatio: 1.0 }, (decodedText) => {
+                BlueChat.QRManager.stopScanner();
+                onResult(decodedText);
+            }, () => { });
+        },
+        stopScanner() {
+            if (activeScanner) {
+                const scanner = activeScanner;
+                activeScanner = null;
+                try {
+                    if (scanner.isScanning) {
+                        scanner.stop().catch(() => { });
+                    }
+                }
+                catch ( /* ignore */_a) { /* ignore */ }
+            }
         }
-      } catch (e) {
-        // ignore
-      }
-    }
-  }
-
-  window.BlueChat = window.BlueChat || {};
-  window.BlueChat.QRManager = {
-    displayQR: displayQR,
-    startScanner: startScanner,
-    stopScanner: stopScanner
-  };
-})();
+    };
+})(BlueChat || (BlueChat = {}));
+//# sourceMappingURL=qr-manager.js.map

--- a/js/screens.js
+++ b/js/screens.js
@@ -1,33 +1,28 @@
-(function () {
-  'use strict';
-
-  var SCREENS = ['home', 'host', 'join', 'chat'];
-  var current = 'home';
-  var listeners = [];
-
-  function show(name) {
-    if (SCREENS.indexOf(name) === -1) return;
-    var prev = current;
-    current = name;
-    SCREENS.forEach(function (s) {
-      var el = document.getElementById('screen-' + s);
-      if (el) el.classList.toggle('active', s === name);
-    });
-    listeners.forEach(function (fn) { fn(name, prev); });
-  }
-
-  function getCurrent() {
-    return current;
-  }
-
-  function onChange(fn) {
-    listeners.push(fn);
-  }
-
-  window.BlueChat = window.BlueChat || {};
-  window.BlueChat.Screens = {
-    show: show,
-    getCurrent: getCurrent,
-    onChange: onChange
-  };
-})();
+"use strict";
+var BlueChat;
+(function (BlueChat) {
+    const SCREENS = ['home', 'host', 'join', 'chat'];
+    let current = 'home';
+    const listeners = [];
+    BlueChat.Screens = {
+        show(name) {
+            if (SCREENS.indexOf(name) === -1)
+                return;
+            const prev = current;
+            current = name;
+            SCREENS.forEach(s => {
+                const el = document.getElementById('screen-' + s);
+                if (el)
+                    el.classList.toggle('active', s === name);
+            });
+            listeners.forEach(fn => fn(name, prev));
+        },
+        getCurrent() {
+            return current;
+        },
+        onChange(fn) {
+            listeners.push(fn);
+        }
+    };
+})(BlueChat || (BlueChat = {}));
+//# sourceMappingURL=screens.js.map

--- a/js/sdp-compress.js
+++ b/js/sdp-compress.js
@@ -1,106 +1,86 @@
-(function () {
-  'use strict';
-
-  // Extract only the essential fields from SDP needed for local network WebRTC
-  function stripSDP(sdp) {
-    var lines = sdp.split('\r\n');
-    var essential = {
-      type: '', // offer or answer
-      fp: '',   // DTLS fingerprint
-      ufrag: '',
-      pwd: '',
-      candidates: []
-    };
-
-    for (var i = 0; i < lines.length; i++) {
-      var line = lines[i];
-      if (line.indexOf('a=fingerprint:') === 0) {
-        essential.fp = line.substring('a=fingerprint:'.length);
-      } else if (line.indexOf('a=ice-ufrag:') === 0) {
-        essential.ufrag = line.substring('a=ice-ufrag:'.length);
-      } else if (line.indexOf('a=ice-pwd:') === 0) {
-        essential.pwd = line.substring('a=ice-pwd:'.length);
-      } else if (line.indexOf('a=candidate:') === 0) {
-        essential.candidates.push(line.substring('a=candidate:'.length));
-      }
+"use strict";
+var BlueChat;
+(function (BlueChat) {
+    function stripSDP(sdp) {
+        const lines = sdp.split('\r\n');
+        const essential = { fp: '', ufrag: '', pwd: '', candidates: [] };
+        for (const line of lines) {
+            if (line.startsWith('a=fingerprint:')) {
+                essential.fp = line.substring('a=fingerprint:'.length);
+            }
+            else if (line.startsWith('a=ice-ufrag:')) {
+                essential.ufrag = line.substring('a=ice-ufrag:'.length);
+            }
+            else if (line.startsWith('a=ice-pwd:')) {
+                essential.pwd = line.substring('a=ice-pwd:'.length);
+            }
+            else if (line.startsWith('a=candidate:')) {
+                essential.candidates.push(line.substring('a=candidate:'.length));
+            }
+        }
+        return essential;
     }
-
-    return essential;
-  }
-
-  // Rebuild a minimal SDP from stripped fields
-  function rebuildSDP(essential, type) {
-    var sdp = [
-      'v=0',
-      'o=- 0 0 IN IP4 0.0.0.0',
-      's=-',
-      't=0 0',
-      'a=group:BUNDLE 0',
-      'a=msid-semantic:WMS',
-      'm=application 9 UDP/DTLS/SCTP webrtc-datachannel',
-      'c=IN IP4 0.0.0.0',
-      'a=mid:0',
-      'a=sctp-port:5000',
-      'a=max-message-size:262144',
-      'a=ice-ufrag:' + essential.ufrag,
-      'a=ice-pwd:' + essential.pwd,
-      'a=fingerprint:' + essential.fp,
-      'a=setup:' + (type === 'offer' ? 'actpass' : 'active')
-    ];
-
-    for (var i = 0; i < essential.candidates.length; i++) {
-      sdp.push('a=candidate:' + essential.candidates[i]);
+    function rebuildSDP(essential, type) {
+        const sdp = [
+            'v=0',
+            'o=- 0 0 IN IP4 0.0.0.0',
+            's=-',
+            't=0 0',
+            'a=group:BUNDLE 0',
+            'a=msid-semantic:WMS',
+            'm=application 9 UDP/DTLS/SCTP webrtc-datachannel',
+            'c=IN IP4 0.0.0.0',
+            'a=mid:0',
+            'a=sctp-port:5000',
+            'a=max-message-size:262144',
+            'a=ice-ufrag:' + essential.ufrag,
+            'a=ice-pwd:' + essential.pwd,
+            'a=fingerprint:' + essential.fp,
+            'a=setup:' + (type === 'offer' ? 'actpass' : 'active')
+        ];
+        for (const c of essential.candidates) {
+            sdp.push('a=candidate:' + c);
+        }
+        sdp.push('');
+        return sdp.join('\r\n');
     }
-
-    sdp.push('');
-    return sdp.join('\r\n');
-  }
-
-  // Compress SDP for QR code transport
-  function compress(sdp, type, deviceId) {
-    var essential = stripSDP(sdp);
-    var payload = {
-      t: type === 'offer' ? 'o' : 'a',
-      f: essential.fp,
-      u: essential.ufrag,
-      p: essential.pwd,
-      c: essential.candidates,
-      id: deviceId || ''
+    BlueChat.SDPCompress = {
+        compress(sdp, type, deviceId) {
+            const essential = stripSDP(sdp);
+            const payload = {
+                t: type === 'offer' ? 'o' : 'a',
+                f: essential.fp,
+                u: essential.ufrag,
+                p: essential.pwd,
+                c: essential.candidates,
+                id: deviceId || ''
+            };
+            return LZString.compressToEncodedURIComponent(JSON.stringify(payload));
+        },
+        decompress(compressed) {
+            const json = LZString.decompressFromEncodedURIComponent(compressed);
+            if (!json)
+                return null;
+            let payload;
+            try {
+                payload = JSON.parse(json);
+            }
+            catch (_a) {
+                return null;
+            }
+            const type = payload.t === 'o' ? 'offer' : 'answer';
+            const essential = {
+                fp: payload.f,
+                ufrag: payload.u,
+                pwd: payload.p,
+                candidates: payload.c || []
+            };
+            return {
+                sdp: rebuildSDP(essential, type),
+                type,
+                peerId: payload.id || ''
+            };
+        }
     };
-    var json = JSON.stringify(payload);
-    return LZString.compressToEncodedURIComponent(json);
-  }
-
-  // Decompress QR code data back to SDP
-  function decompress(compressed) {
-    var json = LZString.decompressFromEncodedURIComponent(compressed);
-    if (!json) return null;
-
-    var payload;
-    try {
-      payload = JSON.parse(json);
-    } catch (e) {
-      return null;
-    }
-
-    var type = payload.t === 'o' ? 'offer' : 'answer';
-    var essential = {
-      fp: payload.f,
-      ufrag: payload.u,
-      pwd: payload.p,
-      candidates: payload.c || []
-    };
-
-    return {
-      sdp: rebuildSDP(essential, type),
-      type: type,
-      peerId: payload.id || ''
-    };
-  }
-
-  window.BlueChat = window.BlueChat || {};
-  window.BlueChat.SDPCompress = {
-    compress: compress,
-    decompress: decompress
-  };
-})();
+})(BlueChat || (BlueChat = {}));
+//# sourceMappingURL=sdp-compress.js.map

--- a/js/toast.js
+++ b/js/toast.js
@@ -1,0 +1,20 @@
+"use strict";
+var BlueChat;
+(function (BlueChat) {
+    BlueChat.Toast = {
+        show(msg, isError = false) {
+            const container = document.getElementById('toast-container');
+            if (!container)
+                return;
+            const el = document.createElement('div');
+            el.className = 'toast' + (isError ? ' toast-error' : '');
+            el.textContent = msg;
+            container.appendChild(el);
+            setTimeout(() => {
+                el.classList.add('toast-out');
+                setTimeout(() => el.remove(), 300);
+            }, 5000);
+        }
+    };
+})(BlueChat || (BlueChat = {}));
+//# sourceMappingURL=toast.js.map

--- a/js/transport.js
+++ b/js/transport.js
@@ -1,53 +1,30 @@
-(function () {
-  'use strict';
-
-  // Abstract Transport base class using EventTarget
-  // Events: 'message', 'connected', 'disconnected'
-  // Subclasses implement: createOffer, acceptOffer, completeConnection, send, disconnect
-
-  function Transport() {
-    this._listeners = {};
-  }
-
-  Transport.prototype.on = function (event, fn) {
-    if (!this._listeners[event]) this._listeners[event] = [];
-    this._listeners[event].push(fn);
-  };
-
-  Transport.prototype.off = function (event, fn) {
-    if (!this._listeners[event]) return;
-    this._listeners[event] = this._listeners[event].filter(function (f) { return f !== fn; });
-  };
-
-  Transport.prototype.emit = function (event, data) {
-    var fns = this._listeners[event];
-    if (!fns) return;
-    for (var i = 0; i < fns.length; i++) {
-      fns[i](data);
+"use strict";
+var BlueChat;
+(function (BlueChat) {
+    class TransportBase {
+        constructor() {
+            this._listeners = {};
+        }
+        on(event, fn) {
+            if (!this._listeners[event])
+                this._listeners[event] = [];
+            this._listeners[event].push(fn);
+        }
+        off(event, fn) {
+            const fns = this._listeners[event];
+            if (!fns)
+                return;
+            this._listeners[event] = fns.filter(f => f !== fn);
+        }
+        emit(event, ...args) {
+            const fns = this._listeners[event];
+            if (!fns)
+                return;
+            for (const fn of fns) {
+                fn(args[0]);
+            }
+        }
     }
-  };
-
-  // To be overridden by subclass
-  Transport.prototype.createOffer = function () {
-    return Promise.reject(new Error('Not implemented'));
-  };
-
-  Transport.prototype.acceptOffer = function (/* offerData */) {
-    return Promise.reject(new Error('Not implemented'));
-  };
-
-  Transport.prototype.completeConnection = function (/* answerData */) {
-    return Promise.reject(new Error('Not implemented'));
-  };
-
-  Transport.prototype.send = function (/* message */) {
-    throw new Error('Not implemented');
-  };
-
-  Transport.prototype.disconnect = function () {
-    throw new Error('Not implemented');
-  };
-
-  window.BlueChat = window.BlueChat || {};
-  window.BlueChat.Transport = Transport;
-})();
+    BlueChat.TransportBase = TransportBase;
+})(BlueChat || (BlueChat = {}));
+//# sourceMappingURL=transport.js.map

--- a/js/types.js
+++ b/js/types.js
@@ -1,0 +1,2 @@
+"use strict";
+//# sourceMappingURL=types.js.map

--- a/js/webrtc-transport.js
+++ b/js/webrtc-transport.js
@@ -1,147 +1,119 @@
-(function () {
-  'use strict';
-
-  var Transport = window.BlueChat.Transport;
-
-  function WebRTCTransport() {
-    Transport.call(this);
-    this.pc = null;
-    this.dc = null;
-    this._connected = false;
-  }
-
-  // Inherit from Transport
-  WebRTCTransport.prototype = Object.create(Transport.prototype);
-  WebRTCTransport.prototype.constructor = WebRTCTransport;
-
-  WebRTCTransport.prototype._createPC = function () {
-    var self = this;
-    // No STUN/TURN — local network only
-    this.pc = new RTCPeerConnection({ iceServers: [] });
-
-    // Only use ICE state for disconnection detection.
-    // Connection is signaled by dc.onopen (DataChannel ready).
-    this.pc.oniceconnectionstatechange = function () {
-      var state = self.pc.iceConnectionState;
-      if (state === 'disconnected' || state === 'failed' || state === 'closed') {
-        if (self._connected) {
-          self._connected = false;
-          self.emit('disconnected');
+"use strict";
+var BlueChat;
+(function (BlueChat) {
+    const DEFAULT_GATHERING_TIMEOUT = 5000;
+    class WebRTCTransport extends BlueChat.TransportBase {
+        constructor(config = {}) {
+            var _a, _b;
+            super();
+            this.pc = null;
+            this.dc = null;
+            this._connected = false;
+            this.config = {
+                iceServers: (_a = config.iceServers) !== null && _a !== void 0 ? _a : [],
+                gatheringTimeout: (_b = config.gatheringTimeout) !== null && _b !== void 0 ? _b : DEFAULT_GATHERING_TIMEOUT
+            };
         }
-      }
-    };
-  };
-
-  WebRTCTransport.prototype._setupDC = function (dc) {
-    var self = this;
-    this.dc = dc;
-
-    dc.onopen = function () {
-      if (!self._connected) {
-        self._connected = true;
-        self.emit('connected');
-      }
-    };
-
-    dc.onclose = function () {
-      if (self._connected) {
-        self._connected = false;
-        self.emit('disconnected');
-      }
-    };
-
-    dc.onmessage = function (e) {
-      self.emit('message', e.data);
-    };
-  };
-
-  // Host side: create offer and wait for ICE candidates to gather
-  WebRTCTransport.prototype.createOffer = function () {
-    var self = this;
-    this._createPC();
-
-    var dc = this.pc.createDataChannel('chat', { ordered: true });
-    this._setupDC(dc);
-
-    return this.pc.createOffer().then(function (offer) {
-      return self.pc.setLocalDescription(offer);
-    }).then(function () {
-      return self._waitForICE();
-    }).then(function () {
-      return self.pc.localDescription.sdp;
-    });
-  };
-
-  // Joiner side: accept offer and return answer SDP
-  WebRTCTransport.prototype.acceptOffer = function (offerSDP) {
-    var self = this;
-    this._createPC();
-
-    this.pc.ondatachannel = function (e) {
-      self._setupDC(e.channel);
-    };
-
-    var offer = new RTCSessionDescription({ type: 'offer', sdp: offerSDP });
-    return this.pc.setRemoteDescription(offer).then(function () {
-      return self.pc.createAnswer();
-    }).then(function (answer) {
-      return self.pc.setLocalDescription(answer);
-    }).then(function () {
-      return self._waitForICE();
-    }).then(function () {
-      return self.pc.localDescription.sdp;
-    });
-  };
-
-  // Host side: complete connection with answer
-  WebRTCTransport.prototype.completeConnection = function (answerSDP) {
-    var answer = new RTCSessionDescription({ type: 'answer', sdp: answerSDP });
-    return this.pc.setRemoteDescription(answer);
-  };
-
-  WebRTCTransport.prototype.send = function (message) {
-    if (this.dc && this.dc.readyState === 'open') {
-      this.dc.send(message);
-    }
-  };
-
-  WebRTCTransport.prototype.disconnect = function () {
-    if (this.dc) {
-      try { this.dc.close(); } catch (e) { /* ignore */ }
-      this.dc = null;
-    }
-    if (this.pc) {
-      try { this.pc.close(); } catch (e) { /* ignore */ }
-      this.pc = null;
-    }
-    this._connected = false;
-  };
-
-  // Wait for ICE gathering to complete (or timeout with what we have)
-  WebRTCTransport.prototype._waitForICE = function () {
-    var self = this;
-    return new Promise(function (resolve) {
-      if (self.pc.iceGatheringState === 'complete') {
-        resolve();
-        return;
-      }
-
-      var timeout = setTimeout(function () {
-        // Use what we have after timeout
-        self.pc.onicecandidate = null;
-        resolve();
-      }, 3000);
-
-      self.pc.onicecandidate = function (e) {
-        if (e.candidate === null) {
-          // Gathering complete
-          clearTimeout(timeout);
-          resolve();
+        _createPC() {
+            this.pc = new RTCPeerConnection({
+                iceServers: this.config.iceServers
+            });
+            // Only use ICE state for disconnection detection.
+            // Connection is signaled by dc.onopen (DataChannel ready).
+            this.pc.oniceconnectionstatechange = () => {
+                const state = this.pc.iceConnectionState;
+                if (state === 'disconnected' || state === 'failed' || state === 'closed') {
+                    if (this._connected) {
+                        this._connected = false;
+                        this.emit('disconnected');
+                    }
+                }
+            };
         }
-      };
-    });
-  };
-
-  window.BlueChat = window.BlueChat || {};
-  window.BlueChat.WebRTCTransport = WebRTCTransport;
-})();
+        _setupDC(dc) {
+            this.dc = dc;
+            dc.onopen = () => {
+                if (!this._connected) {
+                    this._connected = true;
+                    this.emit('connected');
+                }
+            };
+            dc.onclose = () => {
+                if (this._connected) {
+                    this._connected = false;
+                    this.emit('disconnected');
+                }
+            };
+            dc.onmessage = (e) => {
+                this.emit('message', e.data);
+            };
+        }
+        async createInvite() {
+            this._createPC();
+            const dc = this.pc.createDataChannel('chat', { ordered: true });
+            this._setupDC(dc);
+            const offer = await this.pc.createOffer();
+            await this.pc.setLocalDescription(offer);
+            await this._waitForICE();
+            return this.pc.localDescription.sdp;
+        }
+        async acceptInvite(offerSDP) {
+            this._createPC();
+            this.pc.ondatachannel = (e) => {
+                this._setupDC(e.channel);
+            };
+            const offer = new RTCSessionDescription({ type: 'offer', sdp: offerSDP });
+            await this.pc.setRemoteDescription(offer);
+            const answer = await this.pc.createAnswer();
+            await this.pc.setLocalDescription(answer);
+            await this._waitForICE();
+            return this.pc.localDescription.sdp;
+        }
+        async completeHandshake(answerSDP) {
+            const answer = new RTCSessionDescription({ type: 'answer', sdp: answerSDP });
+            await this.pc.setRemoteDescription(answer);
+        }
+        send(message) {
+            if (this.dc && this.dc.readyState === 'open') {
+                this.dc.send(message);
+            }
+        }
+        disconnect() {
+            if (this.dc) {
+                try {
+                    this.dc.close();
+                }
+                catch ( /* ignore */_a) { /* ignore */ }
+                this.dc = null;
+            }
+            if (this.pc) {
+                try {
+                    this.pc.close();
+                }
+                catch ( /* ignore */_b) { /* ignore */ }
+                this.pc = null;
+            }
+            this._connected = false;
+        }
+        _waitForICE() {
+            return new Promise(resolve => {
+                if (this.pc.iceGatheringState === 'complete') {
+                    resolve();
+                    return;
+                }
+                const timeout = setTimeout(() => {
+                    this.pc.onicecandidate = null;
+                    resolve();
+                }, this.config.gatheringTimeout);
+                this.pc.onicecandidate = (e) => {
+                    if (e.candidate === null) {
+                        clearTimeout(timeout);
+                        resolve();
+                    }
+                };
+            });
+        }
+    }
+    BlueChat.WebRTCTransport = WebRTCTransport;
+})(BlueChat || (BlueChat = {}));
+//# sourceMappingURL=webrtc-transport.js.map

--- a/lib/types/html5-qrcode.d.ts
+++ b/lib/types/html5-qrcode.d.ts
@@ -1,0 +1,11 @@
+declare class Html5Qrcode {
+  constructor(elementId: string);
+  start(
+    cameraIdOrConfig: { facingMode: string } | string,
+    config: { fps: number; qrbox: { width: number; height: number }; aspectRatio: number },
+    onSuccess: (decodedText: string) => void,
+    onFailure: (error: string) => void
+  ): Promise<void>;
+  stop(): Promise<void>;
+  isScanning: boolean;
+}

--- a/lib/types/lz-string.d.ts
+++ b/lib/types/lz-string.d.ts
@@ -1,0 +1,4 @@
+declare namespace LZString {
+  function compressToEncodedURIComponent(input: string): string;
+  function decompressFromEncodedURIComponent(input: string): string | null;
+}

--- a/lib/types/qrcode-generator.d.ts
+++ b/lib/types/qrcode-generator.d.ts
@@ -1,0 +1,7 @@
+declare function qrcode(typeNumber: number, errorCorrectionLevel: string): QRCode;
+
+interface QRCode {
+  addData(data: string): void;
+  make(): void;
+  createDataURL(cellSize?: number, margin?: number): string;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1236 @@
+{
+  "name": "bluechat",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "devDependencies": {
+        "puppeteer": "^24.37.2",
+        "typescript": "^5.7"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@puppeteer/browsers": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.12.0.tgz",
+      "integrity": "sha512-Xuq42yxcQJ54ti8ZHNzF5snFvtpgXzNToJ1bXUGQRaiO8t+B6UM8sTUJfvV+AJnqtkJU/7hdy6nbKyA12aHtRw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "extract-zip": "^2.0.1",
+        "progress": "^2.0.3",
+        "proxy-agent": "^6.5.0",
+        "semver": "^7.7.3",
+        "tar-fs": "^3.1.1",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "browsers": "lib/cjs/main-cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@tootallnate/quickjs-emscripten": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
+      "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "25.2.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.2.1.tgz",
+      "integrity": "sha512-CPrnr8voK8vC6eEtyRzvMpgp3VyVRhgclonE7qYi6P9sXwYb59ucfrnmFBTaP0yUi8Gk4yZg/LlTJULGxvTNsg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/@types/yauzl": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/ast-types": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
+      "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/b4a": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.7.3.tgz",
+      "integrity": "sha512-5Q2mfq2WfGuFp3uS//0s6baOJLMoVduPYVeNmDYxu5OUA1/cBfvr2RIS7vi62LdNj/urk1hfmj867I3qt6uZ7Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-events": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
+      "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-fs": {
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.5.3.tgz",
+      "integrity": "sha512-9+kwVx8QYvt3hPWnmb19tPnh38c6Nihz8Lx3t0g9+4GoIf3/fTgYwM4Z6NxgI+B9elLQA7mLE9PpqcWtOMRDiQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-os": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.6.2.tgz",
+      "integrity": "sha512-T+V1+1srU2qYNBmJCXZkUY5vQ0B4FSlL3QDROnKQYOqeiQR8UbjNHlPa+TIbM4cuidiN9GaTaOZgSEgsvPbh5A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "bare": ">=1.14.0"
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
+      "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "bare-os": "^3.0.1"
+      }
+    },
+    "node_modules/bare-stream": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.7.0.tgz",
+      "integrity": "sha512-oyXQNicV1y8nc2aKffH+BUHFRXmx6VrPzlnaEvMhram0nPBrKcEdcyBg5r08D0i8VxngHFAiVyn1QKXpSG0B8A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "streamx": "^2.21.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.3.2.tgz",
+      "integrity": "sha512-ZMq4gd9ngV5aTMa5p9+UfY0b3skwhHELaDkhEHetMdX0LRkW9kzaym4oo/Eh+Ghm0CCDuMTsRIGM/ytUc1ZYmw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/basic-ftp": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.1.0.tgz",
+      "integrity": "sha512-RkaJzeJKDbaDWTIPiJwubyljaEPwpVWkm9Rt5h9Nd6h7tEXTJ3VB4qxdZBioV7JO5yLUaOKwz7vDOzlncUsegw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chromium-bidi": {
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-13.1.1.tgz",
+      "integrity": "sha512-zB9MpoPd7VJwjowQqiW3FKOvQwffFMjQ8Iejp5ZW+sJaKLRhZX1sTxzl3Zt22TDB4zP0OOqs8lRoY7eAW5geyQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mitt": "^3.0.1",
+        "zod": "^3.24.1"
+      },
+      "peerDependencies": {
+        "devtools-protocol": "*"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cosmiconfig": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
+      "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "env-paths": "^2.2.1",
+        "import-fresh": "^3.3.0",
+        "js-yaml": "^4.1.0",
+        "parse-json": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/d-fischer"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.9.5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+      "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/degenerator": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
+      "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ast-types": "^0.13.4",
+        "escodegen": "^2.1.0",
+        "esprima": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/devtools-protocol": {
+      "version": "0.0.1566079",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1566079.tgz",
+      "integrity": "sha512-MJfAEA1UfVhSs7fbSQOG4czavUp1ajfg6prlAN0+cmfa2zNjaIbvq8VneP7do1WAQQIvgNJWSMeP6UyI90gIlQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escodegen": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
+      }
+    },
+    "node_modules/extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10.17.0"
+      },
+      "optionalDependencies": {
+        "@types/yauzl": "^2.9.1"
+      }
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-uri": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
+      "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "basic-ftp": "^5.0.2",
+        "data-uri-to-buffer": "^6.0.2",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/netmask": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
+      "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/pac-proxy-agent": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
+      "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tootallnate/quickjs-emscripten": "^0.23.0",
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "get-uri": "^6.0.1",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.6",
+        "pac-resolver": "^7.0.1",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/pac-resolver": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
+      "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "degenerator": "^5.0.0",
+        "netmask": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/proxy-agent": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
+      "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "http-proxy-agent": "^7.0.1",
+        "https-proxy-agent": "^7.0.6",
+        "lru-cache": "^7.14.1",
+        "pac-proxy-agent": "^7.1.0",
+        "proxy-from-env": "^1.1.0",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pump": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
+      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/puppeteer": {
+      "version": "24.37.2",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-24.37.2.tgz",
+      "integrity": "sha512-FV1W/919ve0y0oiS/3Rp5XY4MUNUokpZOH/5M4MMDfrrvh6T9VbdKvAHrAFHBuCxvluDxhjra20W7Iz6HJUcIQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@puppeteer/browsers": "2.12.0",
+        "chromium-bidi": "13.1.1",
+        "cosmiconfig": "^9.0.0",
+        "devtools-protocol": "0.0.1566079",
+        "puppeteer-core": "24.37.2",
+        "typed-query-selector": "^2.12.0"
+      },
+      "bin": {
+        "puppeteer": "lib/cjs/puppeteer/node/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/puppeteer-core": {
+      "version": "24.37.2",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.37.2.tgz",
+      "integrity": "sha512-nN8qwE3TGF2vA/+xemPxbesntTuqD9vCGOiZL2uh8HES3pPzLX20MyQjB42dH2rhQ3W3TljZ4ZaKZ0yX/abQuw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@puppeteer/browsers": "2.12.0",
+        "chromium-bidi": "13.1.1",
+        "debug": "^4.4.3",
+        "devtools-protocol": "0.0.1566079",
+        "typed-query-selector": "^2.12.0",
+        "webdriver-bidi-protocol": "0.4.0",
+        "ws": "^8.19.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
+      "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.0.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/streamx": {
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.23.0.tgz",
+      "integrity": "sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.1.tgz",
+      "integrity": "sha512-LZA0oaPOc2fVo82Txf3gw+AkEd38szODlptMYejQUhndHMLQ9M059uXR+AfS7DNo0NpINvSqDsvyaCrBVkptWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0",
+        "tar-stream": "^3.1.5"
+      },
+      "optionalDependencies": {
+        "bare-fs": "^4.0.1",
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
+      "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.3.tgz",
+      "integrity": "sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/typed-query-selector": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.0.tgz",
+      "integrity": "sha512-SbklCd1F0EiZOyPiW192rrHZzZ5sBijB6xM+cpmrwDqObvdtunOHHIk9fCGsoK5JVIYXoyEp4iEdE3upFH3PAg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/webdriver-bidi-protocol": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.4.0.tgz",
+      "integrity": "sha512-U9VIlNRrq94d1xxR9JrCEAx5Gv/2W7ERSv8oWRoNe/QYbfccS0V3h/H6qeNeCRJxXGMhhnkqvwNrvPAYeuP9VA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "private": true,
+  "scripts": {
+    "build": "tsc",
+    "watch": "tsc --watch",
+    "test": "node test-debug-flow.js"
+  },
+  "devDependencies": {
+    "puppeteer": "^24.37.2",
+    "typescript": "^5.7"
+  }
+}

--- a/sw.js
+++ b/sw.js
@@ -1,10 +1,12 @@
-const CACHE_NAME = 'bluechat-v2';
+const CACHE_NAME = 'bluechat-v3';
 const ASSETS = [
   './',
   './index.html',
   './css/style.css',
+  './js/types.js',
   './js/identity.js',
   './js/screens.js',
+  './js/toast.js',
   './js/sdp-compress.js',
   './js/transport.js',
   './js/webrtc-transport.js',

--- a/ts/app.ts
+++ b/ts/app.ts
@@ -1,0 +1,230 @@
+namespace BlueChat {
+
+  let transport: ITransport | null = null;
+  let deviceId = '';
+  let peerId = '';
+  const isDebug = window.location.search.indexOf('debug=true') !== -1;
+
+  // Expose transport for debugging (used by test-debug-flow.js)
+  export let _transport: ITransport | null = null;
+
+  function cleanup(): void {
+    QRManager.stopScanner();
+    if (transport) {
+      transport.disconnect();
+      transport = null;
+      _transport = null;
+    }
+  }
+
+  function setupTransport(): void {
+    _transport = transport;
+
+    transport!.on('connected', () => {
+      Screens.show('chat');
+      Chat.clear();
+      const name = peerId || 'Peer';
+      document.getElementById('peer-name')!.textContent = name;
+      document.getElementById('status-dot')!.classList.remove('disconnected');
+      Chat.addMessage('Connected to ' + name, 'system');
+    });
+
+    transport!.on('disconnected', () => {
+      document.getElementById('status-dot')!.classList.add('disconnected');
+      Chat.addMessage('Peer disconnected', 'system');
+    });
+
+    transport!.on('message', (data: string) => {
+      try {
+        const msg: ChatMessage = JSON.parse(data);
+        if (msg.type === 'chat') {
+          Chat.addMessage(msg.text, 'received');
+        }
+      } catch {
+        Chat.addMessage(data, 'received');
+      }
+    });
+  }
+
+  function sendMessage(text: string): void {
+    if (!transport || !text.trim()) return;
+    const msg: ChatMessage = { type: 'chat', text: text.trim(), from: deviceId };
+    transport.send(JSON.stringify(msg));
+    Chat.addMessage(text.trim(), 'sent');
+  }
+
+  // --- Host flow ---
+
+  function startHost(): void {
+    cleanup();
+    transport = new WebRTCTransport();
+    setupTransport();
+
+    Screens.show('host');
+    document.getElementById('host-instruction')!.textContent = 'Generating connection code...';
+    document.getElementById('host-qr-container')!.innerHTML = '';
+    document.getElementById('host-scanner-container')!.classList.add('hidden');
+    document.getElementById('btn-scan-answer')!.classList.add('hidden');
+
+    transport.createInvite().then(sdp => {
+      const compressed = SDPCompress.compress(sdp, 'offer', deviceId);
+      console.log('Offer compressed length:', compressed.length);
+
+      document.getElementById('host-instruction')!.textContent = 'Show this QR code to your peer';
+      QRManager.displayQR('host-qr-container', compressed);
+
+      if (isDebug) {
+        (document.getElementById('host-offer-text') as HTMLTextAreaElement).value = compressed;
+      }
+
+      // Show "Scan Answer" button (replaces old 5-second auto-switch)
+      if (!isDebug) {
+        document.getElementById('btn-scan-answer')!.classList.remove('hidden');
+      }
+    }).catch(err => {
+      Toast.show('Failed to create offer: ' + err.message, true);
+      console.error(err);
+    });
+  }
+
+  function startAnswerScan(): void {
+    document.getElementById('host-instruction')!.textContent = "Scan your peer's answer QR code";
+    document.getElementById('host-qr-container')!.classList.add('hidden');
+    document.getElementById('btn-scan-answer')!.classList.add('hidden');
+    document.getElementById('host-scanner-container')!.classList.remove('hidden');
+
+    QRManager.startScanner('host-scanner-container', (data: string) => {
+      processAnswer(data);
+    }).catch(err => {
+      Toast.show('Camera error: ' + err, true);
+    });
+  }
+
+  function processAnswer(compressed: string): void {
+    const result = SDPCompress.decompress(compressed);
+    if (!result || result.type !== 'answer') {
+      Toast.show('Invalid answer QR code', true);
+      return;
+    }
+    peerId = result.peerId;
+    transport!.completeHandshake(result.sdp).catch(err => {
+      Toast.show('Connection failed: ' + err.message, true);
+    });
+  }
+
+  // --- Join flow ---
+
+  function startJoin(): void {
+    cleanup();
+    transport = new WebRTCTransport();
+    setupTransport();
+
+    Screens.show('join');
+    document.getElementById('join-instruction')!.textContent = "Scan the host's QR code";
+    document.getElementById('join-qr-container')!.classList.add('hidden');
+    document.getElementById('join-scanner-container')!.classList.remove('hidden');
+
+    if (!isDebug) {
+      QRManager.startScanner('join-scanner-container', (data: string) => {
+        processOffer(data);
+      }).catch(err => {
+        Toast.show('Camera error: ' + err, true);
+      });
+    }
+  }
+
+  function processOffer(compressed: string): void {
+    const result = SDPCompress.decompress(compressed);
+    if (!result || result.type !== 'offer') {
+      Toast.show('Invalid offer QR code', true);
+      return;
+    }
+    peerId = result.peerId;
+
+    document.getElementById('join-instruction')!.textContent = 'Creating answer...';
+
+    transport!.acceptInvite(result.sdp).then(answerSDP => {
+      const answerCompressed = SDPCompress.compress(answerSDP, 'answer', deviceId);
+      console.log('Answer compressed length:', answerCompressed.length);
+
+      document.getElementById('join-instruction')!.textContent = 'Show this QR code to the host';
+      document.getElementById('join-scanner-container')!.classList.add('hidden');
+      document.getElementById('join-qr-container')!.classList.remove('hidden');
+      QRManager.displayQR('join-qr-container', answerCompressed);
+
+      if (isDebug) {
+        (document.getElementById('join-answer-text') as HTMLTextAreaElement).value = answerCompressed;
+      }
+    }).catch(err => {
+      Toast.show('Failed to create answer: ' + err.message, true);
+      console.error(err);
+    });
+  }
+
+  // --- Init ---
+
+  function init(): void {
+    deviceId = Identity.getOrCreate();
+    document.getElementById('device-id')!.textContent = deviceId;
+    Chat.init();
+
+    if (isDebug) {
+      document.querySelectorAll('.debug-panel').forEach(el => {
+        el.classList.remove('hidden');
+      });
+    }
+
+    // Button handlers
+    document.getElementById('btn-new-chat')!.addEventListener('click', startHost);
+    document.getElementById('btn-join-chat')!.addEventListener('click', startJoin);
+    document.getElementById('btn-scan-answer')!.addEventListener('click', startAnswerScan);
+
+    document.getElementById('btn-host-back')!.addEventListener('click', () => {
+      cleanup();
+      Screens.show('home');
+    });
+
+    document.getElementById('btn-join-back')!.addEventListener('click', () => {
+      cleanup();
+      Screens.show('home');
+    });
+
+    document.getElementById('btn-leave')!.addEventListener('click', () => {
+      cleanup();
+      Screens.show('home');
+    });
+
+    // Chat form
+    document.getElementById('chat-form')!.addEventListener('submit', (e: Event) => {
+      e.preventDefault();
+      const input = document.getElementById('chat-input') as HTMLInputElement;
+      sendMessage(input.value);
+      input.value = '';
+    });
+
+    // Debug handlers
+    document.getElementById('host-accept-answer')!.addEventListener('click', () => {
+      const text = (document.getElementById('host-answer-text') as HTMLTextAreaElement).value.trim();
+      if (text) processAnswer(text);
+    });
+
+    document.getElementById('join-process-offer')!.addEventListener('click', () => {
+      const text = (document.getElementById('join-offer-text') as HTMLTextAreaElement).value.trim();
+      if (text) processOffer(text);
+    });
+
+    // Service worker
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker.register('sw.js').catch(err => {
+        console.log('SW registration failed:', err);
+      });
+    }
+  }
+
+  // Boot
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+}

--- a/ts/chat.ts
+++ b/ts/chat.ts
@@ -1,0 +1,44 @@
+namespace BlueChat {
+
+  let messagesEl: HTMLElement | null = null;
+
+  function formatTime(date: Date): string {
+    const h = date.getHours();
+    const m = date.getMinutes();
+    return (h < 10 ? '0' : '') + h + ':' + (m < 10 ? '0' : '') + m;
+  }
+
+  function escapeHTML(text: string): string {
+    const div = document.createElement('div');
+    div.textContent = text;
+    return div.innerHTML;
+  }
+
+  export const Chat = {
+    init(): void {
+      messagesEl = document.getElementById('messages');
+    },
+
+    clear(): void {
+      if (messagesEl) messagesEl.innerHTML = '';
+    },
+
+    addMessage(text: string, type: MessageType): void {
+      if (!messagesEl) return;
+
+      const div = document.createElement('div');
+
+      if (type === 'system') {
+        div.className = 'msg-system';
+        div.textContent = text;
+      } else {
+        div.className = 'msg ' + (type === 'sent' ? 'sent' : 'received');
+        div.innerHTML = escapeHTML(text) +
+          '<span class="msg-time">' + formatTime(new Date()) + '</span>';
+      }
+
+      messagesEl.appendChild(div);
+      messagesEl.scrollTop = messagesEl.scrollHeight;
+    }
+  };
+}

--- a/ts/identity.ts
+++ b/ts/identity.ts
@@ -1,0 +1,38 @@
+namespace BlueChat {
+
+  const ADJECTIVES: string[] = [
+    'bold', 'calm', 'cool', 'dark', 'fast', 'kind', 'keen', 'warm',
+    'wise', 'wild', 'free', 'fair', 'glad', 'gold', 'pink', 'blue',
+    'red', 'soft', 'tall', 'true', 'pure', 'neat', 'slim', 'deep'
+  ];
+
+  const NOUNS: string[] = [
+    'fox', 'owl', 'cat', 'dog', 'elk', 'bee', 'ant', 'bat',
+    'cow', 'emu', 'hen', 'jay', 'ram', 'yak', 'ape', 'cod',
+    'fly', 'gnu', 'hog', 'koi', 'lynx', 'pug', 'ray', 'wolf'
+  ];
+
+  function randomHex(len: number): string {
+    const arr = new Uint8Array(len);
+    crypto.getRandomValues(arr);
+    return Array.from(arr, b => b.toString(16).padStart(2, '0')).join('');
+  }
+
+  function generate(): string {
+    const adj = ADJECTIVES[Math.floor(Math.random() * ADJECTIVES.length)];
+    const noun = NOUNS[Math.floor(Math.random() * NOUNS.length)];
+    return `${adj}-${noun}-${randomHex(2)}`;
+  }
+
+  export const Identity = {
+    getOrCreate(): string {
+      const key = 'bluechat-device-id';
+      let id = localStorage.getItem(key);
+      if (!id) {
+        id = generate();
+        localStorage.setItem(key, id);
+      }
+      return id;
+    }
+  };
+}

--- a/ts/qr-manager.ts
+++ b/ts/qr-manager.ts
@@ -1,0 +1,59 @@
+namespace BlueChat {
+
+  let activeScanner: Html5Qrcode | null = null;
+
+  export const QRManager = {
+    displayQR(containerId: string, data: string): void {
+      const container = document.getElementById(containerId);
+      if (!container) return;
+      container.innerHTML = '';
+
+      try {
+        const qr = qrcode(0, 'L');
+        qr.addData(data);
+        qr.make();
+
+        const size = Math.min(264, window.innerWidth - 80);
+        const img = document.createElement('img');
+        img.src = qr.createDataURL(4, 0);
+        img.width = size;
+        img.height = size;
+        img.alt = 'QR Code';
+        img.style.imageRendering = 'pixelated';
+        container.appendChild(img);
+      } catch (e) {
+        container.textContent = 'QR code too large. Use debug mode (?debug=true).';
+        console.error('QR generation error:', e);
+      }
+    },
+
+    startScanner(containerId: string, onResult: (data: string) => void): Promise<void> {
+      QRManager.stopScanner();
+
+      const scanner = new Html5Qrcode(containerId);
+      activeScanner = scanner;
+
+      return scanner.start(
+        { facingMode: 'environment' },
+        { fps: 10, qrbox: { width: 250, height: 250 }, aspectRatio: 1.0 },
+        (decodedText: string) => {
+          QRManager.stopScanner();
+          onResult(decodedText);
+        },
+        () => { /* ignore scan failures */ }
+      );
+    },
+
+    stopScanner(): void {
+      if (activeScanner) {
+        const scanner = activeScanner;
+        activeScanner = null;
+        try {
+          if (scanner.isScanning) {
+            scanner.stop().catch(() => { /* ignore */ });
+          }
+        } catch { /* ignore */ }
+      }
+    }
+  };
+}

--- a/ts/screens.ts
+++ b/ts/screens.ts
@@ -1,0 +1,27 @@
+namespace BlueChat {
+
+  const SCREENS: ScreenName[] = ['home', 'host', 'join', 'chat'];
+  let current: ScreenName = 'home';
+  const listeners: Array<(name: ScreenName, prev: ScreenName) => void> = [];
+
+  export const Screens = {
+    show(name: ScreenName): void {
+      if (SCREENS.indexOf(name) === -1) return;
+      const prev = current;
+      current = name;
+      SCREENS.forEach(s => {
+        const el = document.getElementById('screen-' + s);
+        if (el) el.classList.toggle('active', s === name);
+      });
+      listeners.forEach(fn => fn(name, prev));
+    },
+
+    getCurrent(): ScreenName {
+      return current;
+    },
+
+    onChange(fn: (name: ScreenName, prev: ScreenName) => void): void {
+      listeners.push(fn);
+    }
+  };
+}

--- a/ts/sdp-compress.ts
+++ b/ts/sdp-compress.ts
@@ -1,0 +1,89 @@
+namespace BlueChat {
+
+  function stripSDP(sdp: string): SDPEssentials {
+    const lines = sdp.split('\r\n');
+    const essential: SDPEssentials = { fp: '', ufrag: '', pwd: '', candidates: [] };
+
+    for (const line of lines) {
+      if (line.startsWith('a=fingerprint:')) {
+        essential.fp = line.substring('a=fingerprint:'.length);
+      } else if (line.startsWith('a=ice-ufrag:')) {
+        essential.ufrag = line.substring('a=ice-ufrag:'.length);
+      } else if (line.startsWith('a=ice-pwd:')) {
+        essential.pwd = line.substring('a=ice-pwd:'.length);
+      } else if (line.startsWith('a=candidate:')) {
+        essential.candidates.push(line.substring('a=candidate:'.length));
+      }
+    }
+
+    return essential;
+  }
+
+  function rebuildSDP(essential: SDPEssentials, type: 'offer' | 'answer'): string {
+    const sdp = [
+      'v=0',
+      'o=- 0 0 IN IP4 0.0.0.0',
+      's=-',
+      't=0 0',
+      'a=group:BUNDLE 0',
+      'a=msid-semantic:WMS',
+      'm=application 9 UDP/DTLS/SCTP webrtc-datachannel',
+      'c=IN IP4 0.0.0.0',
+      'a=mid:0',
+      'a=sctp-port:5000',
+      'a=max-message-size:262144',
+      'a=ice-ufrag:' + essential.ufrag,
+      'a=ice-pwd:' + essential.pwd,
+      'a=fingerprint:' + essential.fp,
+      'a=setup:' + (type === 'offer' ? 'actpass' : 'active')
+    ];
+
+    for (const c of essential.candidates) {
+      sdp.push('a=candidate:' + c);
+    }
+
+    sdp.push('');
+    return sdp.join('\r\n');
+  }
+
+  export const SDPCompress = {
+    compress(sdp: string, type: 'offer' | 'answer', deviceId: string): string {
+      const essential = stripSDP(sdp);
+      const payload: SDPPayload = {
+        t: type === 'offer' ? 'o' : 'a',
+        f: essential.fp,
+        u: essential.ufrag,
+        p: essential.pwd,
+        c: essential.candidates,
+        id: deviceId || ''
+      };
+      return LZString.compressToEncodedURIComponent(JSON.stringify(payload));
+    },
+
+    decompress(compressed: string): DecompressedSDP | null {
+      const json = LZString.decompressFromEncodedURIComponent(compressed);
+      if (!json) return null;
+
+      let payload: SDPPayload;
+      try {
+        payload = JSON.parse(json);
+      } catch {
+        return null;
+      }
+
+      const type = payload.t === 'o' ? 'offer' as const : 'answer' as const;
+      const essential: SDPEssentials = {
+        fp: payload.f,
+        ufrag: payload.u,
+        pwd: payload.p,
+        candidates: payload.c || []
+      };
+
+      return {
+        sdp: rebuildSDP(essential, type),
+        type,
+        peerId: payload.id || ''
+      };
+    }
+  };
+}

--- a/ts/toast.ts
+++ b/ts/toast.ts
@@ -1,0 +1,17 @@
+namespace BlueChat {
+
+  export const Toast = {
+    show(msg: string, isError: boolean = false): void {
+      const container = document.getElementById('toast-container');
+      if (!container) return;
+      const el = document.createElement('div');
+      el.className = 'toast' + (isError ? ' toast-error' : '');
+      el.textContent = msg;
+      container.appendChild(el);
+      setTimeout(() => {
+        el.classList.add('toast-out');
+        setTimeout(() => el.remove(), 300);
+      }, 5000);
+    }
+  };
+}

--- a/ts/transport.ts
+++ b/ts/transport.ts
@@ -1,0 +1,42 @@
+namespace BlueChat {
+
+  export abstract class TransportBase implements ITransport {
+    private _listeners: {
+      [K in keyof TransportEventMap]?: Array<(data: TransportEventMap[K]) => void>;
+    } = {};
+
+    on<K extends keyof TransportEventMap>(
+      event: K,
+      fn: (data: TransportEventMap[K]) => void
+    ): void {
+      if (!this._listeners[event]) this._listeners[event] = [];
+      this._listeners[event]!.push(fn);
+    }
+
+    off<K extends keyof TransportEventMap>(
+      event: K,
+      fn: (data: TransportEventMap[K]) => void
+    ): void {
+      const fns = this._listeners[event];
+      if (!fns) return;
+      this._listeners[event] = fns.filter(f => f !== fn) as typeof fns;
+    }
+
+    protected emit<K extends keyof TransportEventMap>(
+      event: K,
+      ...args: TransportEventMap[K] extends void ? [] : [TransportEventMap[K]]
+    ): void {
+      const fns = this._listeners[event];
+      if (!fns) return;
+      for (const fn of fns) {
+        (fn as (data?: unknown) => void)(args[0]);
+      }
+    }
+
+    abstract createInvite(): Promise<string>;
+    abstract acceptInvite(inviteData: string): Promise<string>;
+    abstract completeHandshake(responseData: string): Promise<void>;
+    abstract send(message: string): void;
+    abstract disconnect(): void;
+  }
+}

--- a/ts/types.ts
+++ b/ts/types.ts
@@ -1,0 +1,72 @@
+namespace BlueChat {
+
+  // --- Screen Management ---
+  export type ScreenName = 'home' | 'host' | 'join' | 'chat';
+
+  // --- Chat Messages ---
+  export type MessageType = 'sent' | 'received' | 'system';
+
+  export interface ChatMessage {
+    type: 'chat';
+    text: string;
+    from: string;
+  }
+
+  // --- Transport ---
+
+  export interface TransportConfig {
+    iceServers?: RTCIceServer[];
+    gatheringTimeout?: number;
+  }
+
+  export interface TransportEventMap {
+    connected: void;
+    disconnected: void;
+    message: string;
+  }
+
+  /**
+   * Transport interface — generic signaling contract.
+   * Not SDP-specific: each implementation defines what the
+   * opaque invite/response strings contain.
+   */
+  export interface ITransport {
+    createInvite(): Promise<string>;
+    acceptInvite(inviteData: string): Promise<string>;
+    completeHandshake(responseData: string): Promise<void>;
+    send(message: string): void;
+    disconnect(): void;
+    on<K extends keyof TransportEventMap>(
+      event: K,
+      fn: (data: TransportEventMap[K]) => void
+    ): void;
+    off<K extends keyof TransportEventMap>(
+      event: K,
+      fn: (data: TransportEventMap[K]) => void
+    ): void;
+  }
+
+  // --- SDP Compression ---
+
+  export interface SDPEssentials {
+    fp: string;
+    ufrag: string;
+    pwd: string;
+    candidates: string[];
+  }
+
+  export interface SDPPayload {
+    t: 'o' | 'a';
+    f: string;
+    u: string;
+    p: string;
+    c: string[];
+    id: string;
+  }
+
+  export interface DecompressedSDP {
+    sdp: string;
+    type: 'offer' | 'answer';
+    peerId: string;
+  }
+}

--- a/ts/webrtc-transport.ts
+++ b/ts/webrtc-transport.ts
@@ -1,0 +1,129 @@
+namespace BlueChat {
+
+  const DEFAULT_GATHERING_TIMEOUT = 5000;
+
+  export class WebRTCTransport extends TransportBase {
+    private pc: RTCPeerConnection | null = null;
+    private dc: RTCDataChannel | null = null;
+    private _connected = false;
+    private config: Required<TransportConfig>;
+
+    constructor(config: TransportConfig = {}) {
+      super();
+      this.config = {
+        iceServers: config.iceServers ?? [],
+        gatheringTimeout: config.gatheringTimeout ?? DEFAULT_GATHERING_TIMEOUT
+      };
+    }
+
+    private _createPC(): void {
+      this.pc = new RTCPeerConnection({
+        iceServers: this.config.iceServers
+      });
+
+      // Only use ICE state for disconnection detection.
+      // Connection is signaled by dc.onopen (DataChannel ready).
+      this.pc.oniceconnectionstatechange = () => {
+        const state = this.pc!.iceConnectionState;
+        if (state === 'disconnected' || state === 'failed' || state === 'closed') {
+          if (this._connected) {
+            this._connected = false;
+            this.emit('disconnected');
+          }
+        }
+      };
+    }
+
+    private _setupDC(dc: RTCDataChannel): void {
+      this.dc = dc;
+
+      dc.onopen = () => {
+        if (!this._connected) {
+          this._connected = true;
+          this.emit('connected');
+        }
+      };
+
+      dc.onclose = () => {
+        if (this._connected) {
+          this._connected = false;
+          this.emit('disconnected');
+        }
+      };
+
+      dc.onmessage = (e: MessageEvent) => {
+        this.emit('message', e.data);
+      };
+    }
+
+    async createInvite(): Promise<string> {
+      this._createPC();
+      const dc = this.pc!.createDataChannel('chat', { ordered: true });
+      this._setupDC(dc);
+
+      const offer = await this.pc!.createOffer();
+      await this.pc!.setLocalDescription(offer);
+      await this._waitForICE();
+      return this.pc!.localDescription!.sdp;
+    }
+
+    async acceptInvite(offerSDP: string): Promise<string> {
+      this._createPC();
+
+      this.pc!.ondatachannel = (e: RTCDataChannelEvent) => {
+        this._setupDC(e.channel);
+      };
+
+      const offer = new RTCSessionDescription({ type: 'offer', sdp: offerSDP });
+      await this.pc!.setRemoteDescription(offer);
+      const answer = await this.pc!.createAnswer();
+      await this.pc!.setLocalDescription(answer);
+      await this._waitForICE();
+      return this.pc!.localDescription!.sdp;
+    }
+
+    async completeHandshake(answerSDP: string): Promise<void> {
+      const answer = new RTCSessionDescription({ type: 'answer', sdp: answerSDP });
+      await this.pc!.setRemoteDescription(answer);
+    }
+
+    send(message: string): void {
+      if (this.dc && this.dc.readyState === 'open') {
+        this.dc.send(message);
+      }
+    }
+
+    disconnect(): void {
+      if (this.dc) {
+        try { this.dc.close(); } catch { /* ignore */ }
+        this.dc = null;
+      }
+      if (this.pc) {
+        try { this.pc.close(); } catch { /* ignore */ }
+        this.pc = null;
+      }
+      this._connected = false;
+    }
+
+    private _waitForICE(): Promise<void> {
+      return new Promise(resolve => {
+        if (this.pc!.iceGatheringState === 'complete') {
+          resolve();
+          return;
+        }
+
+        const timeout = setTimeout(() => {
+          this.pc!.onicecandidate = null;
+          resolve();
+        }, this.config.gatheringTimeout);
+
+        this.pc!.onicecandidate = (e: RTCPeerConnectionIceEvent) => {
+          if (e.candidate === null) {
+            clearTimeout(timeout);
+            resolve();
+          }
+        };
+      });
+    }
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "module": "None",
+    "outDir": "js",
+    "rootDir": "ts",
+    "strict": true,
+    "noEmitOnError": true,
+    "sourceMap": true,
+    "lib": ["ES2017", "DOM", "DOM.Iterable"],
+    "skipLibCheck": true
+  },
+  "include": ["ts/**/*.ts", "lib/types/*.d.ts"]
+}


### PR DESCRIPTION
## Summary

- Migrate all 9 modules from plain JS to TypeScript with strict type checking
- Define typed `ITransport` interface with transport-agnostic method names (`createInvite`, `acceptInvite`, `completeHandshake`)
- Add `TransportConfig` for configurable ICE servers and gathering timeout (ready for STUN/TURN)
- Extract Toast into standalone module, add central `types.ts` with all shared interfaces
- Replace brittle 5-second auto-camera-switch with manual "Scan Answer QR" button
- Add TypeScript build step to CI deploy workflow

## Test plan

- [x] `npx tsc` compiles all 10 `.ts` files with zero errors
- [x] End-to-end puppeteer debug flow: offer → answer → chat → message exchange
- [ ] CI build succeeds on push
- [ ] Live site at dazraf.io/bluechat works after merge

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)