### PR TITLE
Fix page overflow in Brave browser

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -55,6 +55,7 @@
 
 html, body {
   height: 100%;
+  overflow: hidden;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
   font-size: 16px;
   color: var(--text-primary);

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'bluechat-v5';
+const CACHE_NAME = 'bluechat-v6';
 const ASSETS = [
   './',
   './index.html',


### PR DESCRIPTION
## Summary
- Add `overflow: hidden` to `html, body` to prevent body expanding beyond viewport in Brave
- Bump service worker cache to v6 to force refresh of stale cached CSS

Fixes #7

## Test plan
- [x] `npx tsc` compiles with zero errors
- [x] `node test-debug-flow.js` passes
- [x] Brave headless test confirms body matches viewport (800x600, no overflow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)